### PR TITLE
Render dynamic data inside glider-track

### DIFF
--- a/docs/demos.tsx
+++ b/docs/demos.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import DynamicDataGlider from "../examples/dynamicDataGlider";
 import SingleItemGlider from "../examples/singleItemGlider";
 import MultipleItemsGlider from "../examples/multipleItemsGlider";
 import ResponsiveGlider from "../examples/responsiveGlider";
@@ -71,6 +72,10 @@ function Demos() {
       <div className="item">
         <h3>Skip Track</h3>
         <SkipTrackGlider />
+      </div>
+      <div className="item">
+        <h3>Dynamic Data</h3>
+        <DynamicDataGlider />
       </div>
     </div>
   );

--- a/examples/dynamicDataGlider.tsx
+++ b/examples/dynamicDataGlider.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import Glider from "../src";
+
+function DynamicDataGlider() {
+  const [data, setData] = React.useState([1, 2, 3, 4, 5, 6]);
+
+  return (
+    <div className="container">
+      <input
+        type="button"
+        onClick={() => {
+          const newData = [
+            ...new Array(Math.floor(Math.random() * 12) + 1),
+          ].map((_, index) => index + 1);
+          setData(newData);
+        }}
+        value="Randomize"
+      />
+      <div className="container">
+        <Glider
+          className="glider-container"
+          slidesToShow={1}
+          scrollLock
+          hasDots
+          draggable
+        >
+          {data.map((n) => (
+            <div key={n} className="slide">
+              <span>{n}</span>
+            </div>
+          ))}
+        </Glider>
+      </div>
+    </div>
+  );
+}
+
+export default DynamicDataGlider;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ const makeGliderOptions: (
   ...restProps
 }) => ({
   ...restProps,
+  skipTrack: true,
   arrows:
     (hasArrows && {
       next: (arrows && arrows.next) || nextButtonEl,
@@ -42,6 +43,7 @@ const GliderComponent = React.forwardRef(
       scrollToPage,
       iconLeft,
       iconRight,
+      skipTrack,
       children,
       onLoad,
       onSlideVisible,
@@ -222,7 +224,7 @@ const GliderComponent = React.forwardRef(
         )}
 
         <div id={id || autoId} className={className} ref={callbackRef}>
-          {children}
+          {skipTrack ? children : <div>{children}</div>}
         </div>
 
         {hasDots && !dots && <div ref={dotsRef} />}


### PR DESCRIPTION
`children` are placed inside a `div` if `skipTrack` is falsy. This resolves the following exception in React when cleaning up dynamic data since the `key` prop would not match what is in the DOM and the slides would not be updated until re-mounted.

> Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.

Closes #121 